### PR TITLE
Fix Ruby link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 Jekyll is a simple, blog-aware, static site generator. It takes a template directory containing raw text files in various formats, runs it through Markdown and Liquid converters, and spits out a complete, ready-to-publish static website suitable for serving with your favorite web server. Jekyll also happens to be the engine behind GitHub Pages, which means you can use Jekyll to host your project's page, blog, or website from GitHub's servers for free (taken from Jekyll's website: http://jekyllrb.com/docs/home/).
 
 ### Get your workstation set up
-* Install <a href="https://www.ruby-lang.org/en/downloads/>Ruby</a>
+* Install <a href="https://www.ruby-lang.org/en/downloads/">Ruby</a>
 * Install <a href="rubygems.org/pages/download">RubyGems</a>
 * Install <a href="nodejs.org">NodeJS</a>
 * Install <a href="jekyllrb.com/docs/installation">Jekyll</a>


### PR DESCRIPTION
Added a missing quotation mark in the `<a href>` tag